### PR TITLE
SNOW-608673 Reorder set endpoint and update Readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -37,7 +37,7 @@ Variables needed for running tests
 =================================
 ```
          [variables]                    [description]
-       BUCKET_NAME_1              The bucket name for testing, locate at REGION_1.
+       BUCKET_NAME_1              The bucket name for testing, locate at REGION_1, expect versioning enabled.
        REGION_1                   Region for the above bucket, like us-east-1.
        REGION_2                   Region that is different than REGION_1, like us-west-2.
        S3COMPAT_ACCESS_KEY        Access key to used to acess to the above bucket.

--- a/s3compatapi/src/main/java/com/snowflake/s3compatapitestsuite/compatapi/S3CompatStorageClient.java
+++ b/s3compatapi/src/main/java/com/snowflake/s3compatapitestsuite/compatapi/S3CompatStorageClient.java
@@ -83,6 +83,11 @@ public class S3CompatStorageClient implements StorageClient {
             if (measurementPerformance && perfMeasurement != null) {
                 perfMeasurement.recordElapsedTime(PerfMeasurement.FUNC_NAME.GET_BUCKET_LOCATION);
             }
+            if ("US".equals(regionRes)) {
+                // For backward compatibility reasons, AWS returns "US" for the standard region in
+                // us-east-1.
+                regionRes = "us-east-1";
+            }
         } catch (AmazonS3Exception ex) {
             if (ex.getAdditionalDetails() != null) {
                 String correctRegion = ex.getAdditionalDetails().get("Region");

--- a/s3compatapi/src/main/java/com/snowflake/s3compatapitestsuite/compatapi/S3CompatStorageClient.java
+++ b/s3compatapi/src/main/java/com/snowflake/s3compatapitestsuite/compatapi/S3CompatStorageClient.java
@@ -65,10 +65,10 @@ public class S3CompatStorageClient implements StorageClient {
         clientCfg.withSocketTimeout(TIME_OUT);
         clientCfg.withTcpKeepAlive(true);
         AmazonS3 s3Client = new AmazonS3Client(awsCredentialsProvide, clientCfg);
-        s3Client.setEndpoint(endpoint);
         if (region != null) {
             s3Client.setRegion(Region.getRegion(Regions.fromName(region)));
         }
+        s3Client.setEndpoint(endpoint);
         s3Client.setS3ClientOptions(S3ClientOptions.builder().setPathStyleAccess(false).build());
         return s3Client;
     }


### PR DESCRIPTION
<!-- Text inside of HTML comment blocks will NOT appear in your pull request description -->
<!-- Formatting information can be found at https://www.markdownguide.org/basic-syntax/ -->
# Overview

SNOW-608673
The order to setRegion and setEndpoint matters. The setRegion() will overwrite the setEndpoint(). See doc here https://github.com/aws/aws-sdk-java/blob/master/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/AmazonS3.java#L272
Without this fix, partners' requests were routing to s3.amazonaws.com.
This PR also maps "US" region to "us-east-1".
I have verified the fix by using values provided by partners.
