### PR TITLE
Make the test for GetBucketLocation comply with what Readme.md states

### DIFF
--- a/s3compatapi/src/test/java/com/snowflake/s3compatapitestsuite/compatapi/S3CompatApiTest.java
+++ b/s3compatapi/src/test/java/com/snowflake/s3compatapitestsuite/compatapi/S3CompatApiTest.java
@@ -84,13 +84,17 @@ class S3CompatApiTest {
     void getBucketLocation() throws Exception {
         updatePrefixForTestCase(TestUtils.OPERATIONS.GET_BUCKET_LOCATION);
         // positive tests:
-        Assertions.assertEquals(EnvConstants.REGION_1, clientWithRegion1.getBucketLocation(EnvConstants.BUCKET_AT_REGION_1));
-        Assertions.assertEquals(EnvConstants.REGION_1, clientWithNoRegionSpecified.getBucketLocation(EnvConstants.BUCKET_AT_REGION_1));
-        Assertions.assertEquals(EnvConstants.REGION_1, clientWithRegion2.getBucketLocation(EnvConstants.BUCKET_AT_REGION_1));
-        // test get bucket region through metadata request, if below tests fail, see Readme.md troubleshooting session
-        Assertions.assertEquals(EnvConstants.REGION_1, clientWithRegion1.getBucketRegionThroughMetadata(EnvConstants.BUCKET_AT_REGION_1));
-        Assertions.assertEquals(EnvConstants.REGION_1, clientWithRegion2.getBucketRegionThroughMetadata(EnvConstants.BUCKET_AT_REGION_1));
-        Assertions.assertEquals(EnvConstants.REGION_1, clientWithNoRegionSpecified.getBucketRegionThroughMetadata(EnvConstants.BUCKET_AT_REGION_1));
+        if (!clientWithRegion1.getBucketLocation(EnvConstants.BUCKET_AT_REGION_1).equals(EnvConstants.REGION_1)) {
+            // If getting bucket region through metadata request fails, see
+            // Troubleshooting section in Readme.md.
+            Assertions.assertEquals(EnvConstants.REGION_1, clientWithRegion1.getBucketRegionThroughMetadata(EnvConstants.BUCKET_AT_REGION_1));
+        }
+        if (!clientWithNoRegionSpecified.getBucketLocation(EnvConstants.BUCKET_AT_REGION_1).equals(EnvConstants.REGION_1)) {
+            Assertions.assertEquals(EnvConstants.REGION_1, clientWithRegion2.getBucketRegionThroughMetadata(EnvConstants.BUCKET_AT_REGION_1));
+        }
+        if (!clientWithRegion2.getBucketLocation(EnvConstants.BUCKET_AT_REGION_1).equals(EnvConstants.REGION_1)) {
+            Assertions.assertEquals(EnvConstants.REGION_1, clientWithNoRegionSpecified.getBucketRegionThroughMetadata(EnvConstants.BUCKET_AT_REGION_1));
+        }
         // Negative test: bucket does not exist
         TestUtils.functionCallThrowsException(() -> clientWithNoRegionSpecified.getBucketLocation(EnvConstants.NOT_EXISTING_BUCKET),
                 404 /* expectedStatusCode */,


### PR DESCRIPTION
<!-- Text inside of HTML comment blocks will NOT appear in your pull request description -->
<!-- Formatting information can be found at https://www.markdownguide.org/basic-syntax/ -->
# Overview

SNOW-XXXXX
## External contributors - please answer these questions before submitting a pull request. Thanks!

Please answer these questions before submitting your pull requests. Thanks!

1. What GitHub issue is this PR adressing? Make sure that there is an accompanying issue to your PR.

   The change was so small that I thought I can get away with a well-written description of changes being made. I can make an issue if it's really important, though.

2. Fill out the following pre-review checklist:

    - [ ] I am adding a new automated test(s) to verify correctness of my new code
    - [ ] I am adding new logging messages
    - [ ] I am adding a new dependency
    - [ ] I am adding new API testing
    - [x] I am fixing a test

3. Please describe how your code solves the related issue.

   From Readme.md: "[…] your service should support getObjectMetadata() responded with "x-amz-bucket-region" header OR support getBucketLocation().". The issue that was bugging me is that getBucketLocation test is testing support for both "x-amz-bucket-region" AND getBucketLocation() whereas Readme.md is clear about allowing the support for just one, whichever works. This change fixes that.

## Pre-review checklist
- [x] This change has passed precommit
- [x] I have code coverage for my PR